### PR TITLE
Remove escaping in CLI prompt formatting

### DIFF
--- a/utils/prompt_formatter.py
+++ b/utils/prompt_formatter.py
@@ -76,11 +76,9 @@ Base directory: {base_path}
     def format_for_cli(self, instance: Dict) -> str:
         """Format the prompt for Claude Code CLI execution."""
         base_prompt = self.format_issue(instance)
-        
-        # Escape quotes and special characters for shell
-        escaped_prompt = base_prompt.replace('"', '\\"').replace('$', '\\$').replace('`', '\\`')
-        
-        return escaped_prompt
+
+        # Return the raw prompt without escaping for CLI input
+        return base_prompt
     
     def extract_instance_info(self, instance: Dict) -> Dict:
         """Extract key information from a SWE-bench instance."""


### PR DESCRIPTION
## Summary
- stop escaping special characters when preparing CLI prompts
- ensure CLI executions still pass prompts directly via `subprocess.run` without a shell
- demonstrate quotes and `$` survive CLI round-trip without added backslashes

## Testing
- `pytest`
- `python - <<'PY'
from utils.prompt_formatter import PromptFormatter
pf = PromptFormatter()
instance = {
    'repo': 'test/repo',
    'problem_statement': 'This issue includes "quotes", dollar signs like $HOME, and backticks `code`.',
    'instance_id': 'demo',
    'base_commit': 'abc123'
}
prompt = pf.format_for_cli(instance)
import subprocess
result = subprocess.run(['cat'], input=prompt, text=True, capture_output=True)
print('CLI OUTPUT MATCHES PROMPT:', result.stdout == prompt)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c4f7bf2c188321888ba2a1b98251dd