### PR TITLE
Handle zero generation scores in stats

### DIFF
--- a/show_scores.py
+++ b/show_scores.py
@@ -113,7 +113,10 @@ class ScoreViewer:
                 avg_eval = sum(eval_scores)/len(eval_scores)
                 drop = avg_gen - avg_eval
                 print(f"\nAverage drop from generation to evaluation: {drop:.1f}%")
-                print(f"Success rate: {avg_eval/avg_gen*100:.1f}% of generated patches actually work")
+                if avg_gen == 0:
+                    print("No patches generated; success rate unavailable.")
+                else:
+                    print(f"Success rate: {avg_eval/avg_gen*100:.1f}% of generated patches actually work")
         
         # Time statistics
         all_gen_times = [s.get("generation_time", 0) for s in scores 

--- a/tests/test_show_scores.py
+++ b/tests/test_show_scores.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from show_scores import ScoreViewer
+
+
+def test_no_patches_generated(capsys):
+    viewer = ScoreViewer()
+    scores = [{
+        "evaluation_status": "completed",
+        "generation_score": 0,
+        "evaluation_score": 0,
+    }]
+
+    viewer.show_statistics(scores)
+    captured = capsys.readouterr()
+    assert "No patches generated; success rate unavailable." in captured.out


### PR DESCRIPTION
## Summary
- avoid division by zero in statistics when no patches were generated by checking `avg_gen`
- print a user-friendly message when success rate is unavailable
- add regression test for zero generation score scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4f9b925ac83219a2769a50721224e