### PR TITLE
Remove CLI prompt escaping

### DIFF
--- a/utils/prompt_formatter.py
+++ b/utils/prompt_formatter.py
@@ -1,4 +1,3 @@
-import json
 import tempfile
 from pathlib import Path
 from typing import Dict, Optional


### PR DESCRIPTION
## Summary
- Return unescaped prompts from format_for_cli
- Clean up unused import in prompt formatter

## Testing
- `python - <<'PY'
import subprocess
prompt = 'She said "hi" and echoed $PATH'
res = subprocess.run(['cat'], input=prompt, text=True, capture_output=True)
print(res.stdout)
PY`
- `python - <<'PY'
from utils.prompt_formatter import PromptFormatter
pf = PromptFormatter()
instance = {'repo':'example/repo','problem_statement':'This "issue" costs $5\nMore text','instance_id':'123','base_commit':'abc123'}
print(pf.format_for_cli(instance))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c570e8763c832188adfefaa12c169b